### PR TITLE
UpdateMap after fetch values from server

### DIFF
--- a/AppBoosterSDK/Assets/AppboosterSDK/Source/Internal/AppBoosterManager.cs
+++ b/AppBoosterSDK/Assets/AppboosterSDK/Source/Internal/AppBoosterManager.cs
@@ -61,7 +61,7 @@ namespace AppboosterSDK.Internal
 			
 			UpdateMap();
 			
-			var authPayload = $"{{\"deviceId\": \"{deviceId}\",\"appsFlyerId\":\"{appsFlyerId}\",\"amplitudeUserId\":\"{amplitudeUserId}\"";
+			var authPayload = $"{{\"deviceId\": \"{deviceId}\",\"appsFlyerId\":\"{appsFlyerId}\",\"amplitudeId\":\"{amplitudeUserId}\"";
 
 			if (deviceProperties.Length > 0)
             {

--- a/AppBoosterSDK/Assets/AppboosterSDK/Source/Internal/AppBoosterManager.cs
+++ b/AppBoosterSDK/Assets/AppboosterSDK/Source/Internal/AppBoosterManager.cs
@@ -134,6 +134,7 @@ namespace AppboosterSDK.Internal
 
 			_experiments = data.experiments ?? new Experiment[0];
 			LocalStorage.SetObjects("experiments", _experiments);
+			UpdateMap();
 
 			await FetchDebugAsync(ct);
 		}


### PR DESCRIPTION
#### :tophat: Что? Зачем?
* Call `UpdateMap()` after values fetched from server so `GetValue` uses new values, not default
* Rename amplitudeId parameter in JWT payload